### PR TITLE
accomodate libsass

### DIFF
--- a/src/_webfonts.helpers.scss
+++ b/src/_webfonts.helpers.scss
@@ -81,7 +81,10 @@
  */
 @function str-capitalise($string) {
     $string: $string + unquote(''); // Make sure $string has a type of String
-    $first-letter: to-upper-case(str-slice($string, 0, 1));
+
+    // force libsass to not return double quotes around the uppercased string
+    // with an ` + unquote('')`
+    $first-letter: to-upper-case(str-slice($string, 0, 1)) + unquote('');
     $rest-of-string: str-slice($string, 2);
 
     @return $first-letter + $rest-of-string;


### PR DESCRIPTION
in libsass, `to-upper-case` wrongly wraps the return value in two `"`. 

this coerces it into a plain string again, so there is no quotes.